### PR TITLE
Update Api endpoints because sagepay.com will retire soon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -479,3 +479,4 @@ $RECYCLE.BIN/
 ##
 ## Umbraco Commerce specific
 ##
+src/Umbraco.Commerce.PaymentProviders.Opayo/packages.lock.json

--- a/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/OpayoClient.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/OpayoClient.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
         public async Task<Dictionary<string, string>> InitiateTransactionAsync(bool useTestMode, Dictionary<string, string> inputFields, CancellationToken cancellationToken = default)
         {
             var rawResponse = await MakePostRequestAsync(
-                GetMethodUrl(inputFields[OpayoConstants.TransactionRequestFields.TransactionType], useTestMode),
+                OpayoEndpoints.Get(inputFields[OpayoConstants.TransactionRequestFields.TransactionType], useTestMode),
                 inputFields,
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -62,16 +62,6 @@ namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
                 default:
                     return CallbackResult.Empty;
             }
-        }
-
-        private static string GetMethodUrl(string type, bool testMode)
-        {
-            if (testMode)
-            {
-                return OpayoEndpoints.TestEndpoints[type.ToUpperInvariant()];
-            }
-
-            return OpayoEndpoints.LiveEndpoints[type.ToUpperInvariant()];
         }
 
         private async Task<string> MakePostRequestAsync(string url, IDictionary<string, string> inputFields, CancellationToken cancellationToken = default)

--- a/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
 {
     internal static class OpayoEndpoints
     {
-        public static IDictionary<string, string> TestEndpoints => new Dictionary<string, string>
+        private static Dictionary<string, string> TestEndpoints => new()
         {
             { "AUTHORISE", "https://sandbox.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
             { "PAYMENT", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
@@ -14,7 +14,7 @@ namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
             { "REFUND", "https://sandbox.opayo.eu.elavon.com/gateway/service/refund.vsp" },
         };
 
-        public static IDictionary<string, string> LiveEndpoints => new Dictionary<string, string>
+        private static Dictionary<string, string> LiveEndpoints => new()
         {
             { "AUTHORISE", "https://live.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
             { "PAYMENT", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
@@ -23,5 +23,34 @@ namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
             { "CANCEL", "https://live.opayo.eu.elavon.com/gateway/service/cancel.vsp" },
             { "REFUND", "https://live.opayo.eu.elavon.com/gateway/service/refund.vsp" },
         };
+
+        /// <summary>
+        /// Get Opayo endpoint by type.
+        /// </summary>
+        /// <param name="endpointType"></param>
+        /// <param name="isTestMode"></param>
+        /// <returns></returns>
+        /// <exception cref="UnknownEndpointTypeException">Throws exception when unable to get the endpoint.</exception>
+        public static string Get(string endpointType, bool isTestMode)
+        {
+            string normalizeEndpointType = endpointType.ToUpperInvariant();
+
+            if (isTestMode)
+            {
+                if (!TestEndpoints.TryGetValue(normalizeEndpointType, out string testEndpoint))
+                {
+                    throw new UnknownEndpointTypeException(endpointType);
+                }
+
+                return testEndpoint;
+            }
+
+            if (!LiveEndpoints.TryGetValue(normalizeEndpointType, out string liveEndpoint))
+            {
+                throw new UnknownEndpointTypeException(endpointType);
+            }
+
+            return liveEndpoint;
+        }
     }
 }

--- a/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/OpayoEndpoints.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
+{
+    internal static class OpayoEndpoints
+    {
+        public static IDictionary<string, string> TestEndpoints => new Dictionary<string, string>
+        {
+            { "AUTHORISE", "https://sandbox.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
+            { "PAYMENT", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "DEFERRED", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "AUTHENTICATE", "https://sandbox.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "CANCEL", "https://sandbox.opayo.eu.elavon.com/gateway/service/cancel.vsp" },
+            { "REFUND", "https://sandbox.opayo.eu.elavon.com/gateway/service/refund.vsp" },
+        };
+
+        public static IDictionary<string, string> LiveEndpoints => new Dictionary<string, string>
+        {
+            { "AUTHORISE", "https://live.opayo.eu.elavon.com/gateway/service/authorise.vsp" },
+            { "PAYMENT", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "DEFERRED", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "AUTHENTICATE", "https://live.opayo.eu.elavon.com/gateway/service/vspserver-register.vsp" },
+            { "CANCEL", "https://live.opayo.eu.elavon.com/gateway/service/cancel.vsp" },
+            { "REFUND", "https://live.opayo.eu.elavon.com/gateway/service/refund.vsp" },
+        };
+    }
+}

--- a/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/UnknownEndpointTypeException.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Opayo/Api/UnknownEndpointTypeException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Umbraco.Commerce.PaymentProviders.Opayo.Api
+{
+    [Serializable]
+    public class UnknownEndpointTypeException : Exception
+    {
+        private static readonly CompositeFormat _messageTemplate = CompositeFormat.Parse("Unknown endpoint type '{0}'");
+
+        public UnknownEndpointTypeException()
+            : base("Unknown endpoint type")
+        {
+        }
+
+        public UnknownEndpointTypeException(string endpointType)
+            : base(string.Format(CultureInfo.InvariantCulture, _messageTemplate, endpointType))
+        {
+        }
+
+        public UnknownEndpointTypeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
The old ‘sagepay.com’ payment gateway URL is being retired at the end of March so all integrations will need to use their new gateway URL.